### PR TITLE
Upgrade to VMWare Fusion 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ include vmware_fusion
 
 **Note**: While this installs VMware Fusion.app from their DMG, you need to
 run VMware Fusion so the installation completes.
+
+## Specifying a version
+
+If you want to use Fusion 5, you can specify a version:
+
+``` puppet
+class { 'vmware_fusion': version => '5.0.3-1040386' }
+```
+
+or in hiera
+
+``` yaml
+"vmware_fusion::version": "5.0.3-1040386"
+```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,9 +5,11 @@
 # Usage:
 #
 #   include vmware_fusion
-class vmware_fusion {
+class vmware_fusion (
+  $version = '6.0.2-1398658',
+) {
   package { 'VMware Fusion':
-    source   => 'https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-5.0.3-1040386-light.dmg',
+    source   => "https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-${version}-light.dmg",
     provider => 'appdmg'
   }
 }

--- a/spec/classes/vmware_fusion_spec.rb
+++ b/spec/classes/vmware_fusion_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'vmware_fusion' do
   it do
     should contain_package('VMware Fusion').with({
-      :source   => 'https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-5.0.3-1040386-light.dmg',
+      :source   => 'https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-6.0.2-1398658-light.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
The major change in this upgrade is official Mavericks support. See http://www.vmware.com/support/fusion6/doc/fusion-60-release-notes.html for upstream release notes.

I've also added, for those who can't/won't upgrade along with the rest of an org, support for a `version` parameter.
