### PR TITLE
Update version, only apply if you can update the mirror

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 #
 #   include vmware_fusion
 class vmware_fusion (
-  $version = '6.0.2-1398658',
+  $version = '6.0.3-1747349'
 ) {
   package { 'VMware Fusion':
     source   => "https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-${version}-light.dmg",

--- a/spec/classes/vmware_fusion_spec.rb
+++ b/spec/classes/vmware_fusion_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'vmware_fusion' do
   it do
     should contain_package('VMware Fusion').with({
-      :source   => 'https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-6.0.2-1398658-light.dmg',
+      :source   => 'https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-6.0.3-1747349-light.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
This will require an update of the vmware mirror at https://s3.amazonaws.com/boxen-downloads/vmware/
