### PR TITLE
Include version in install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class vmware_fusion (
 
   $url = "${url_base}/VMware-Fusion-${_version}.dmg"
 
-  package { "VMware Fusion_${_version}":
+  package { "VMware_Fusion_${_version}":
     source   => $url,
     provider => 'appdmg'
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class vmware_fusion (
 
   $url = "${url_base}/VMware-Fusion-${_version}.dmg"
 
-  package { "VMware Fusion_${_version}:
+  package { "VMware Fusion_${_version}":
     source   => $url,
     provider => 'appdmg'
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class vmware_fusion (
 
   $url = "${url_base}/VMware-Fusion-${_version}.dmg"
 
-  package { 'VMware Fusion':
+  package { "VMware Fusion_${_version}:
     source   => $url,
     provider => 'appdmg'
   }


### PR DESCRIPTION
Without the version in the install updates are not properly executed for appdmg based installs.
